### PR TITLE
feat(docs): commit CLAUDE.md + AGENTS.md symlink [868jm4wuj]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,26 @@
+# CLAUDE.md -- claude-code-team-commander
+
+## Overview
+
+Public blueprint and playbook for building a shared Claude Code configuration for a team or company. Not a runtime server -- this repo contains documentation, example configs, and setup/audit scripts. Published by OIT, LLC.
+
+## Structure
+
+- `blueprint.md` -- complete system prompt for building your own team config
+- `scripts/audit/` -- audit tooling
+- `examples/` -- example configurations
+- `example-catalog.json` -- sample approved tool catalog
+- `example-announcements.json` -- sample team announcement payloads
+- `example-CLAUDE.md` -- template project-level CLAUDE.md
+- `example-team-announcement.md` -- sample announcement format
+
+## Usage
+
+No build step. This is a reference repo. Teams clone it, customize `blueprint.md` with their org details, and use the generated scripts (`setup.sh`, `catalog.sh`, `bootstrap-repo.sh`) in their own config repo.
+
+## Secrets
+
+- No secrets in this repo -- it is public
+- The generated setup scripts prompt users for API keys at install time
+- Generated `.mcp.json` and `.env` files are gitignored by design
+- Teams should use their own secret management (Azure Key Vault, etc.)


### PR DESCRIPTION
## Summary
- Commit CLAUDE.md as a tracked project file (was untracked local-only).
- Add `AGENTS.md -> CLAUDE.md` symlink so Codex CLI sees the same rules.

## Why
Codex CLI 0.128 reads AGENTS.md per upstream convention. Pre-this-PR, CLAUDE.md content existed locally but wasn't versioned. This PR makes CLAUDE.md the canonical, tracked single-source-of-truth for both Claude Code and Codex sessions in this repo.

Companion to https://app.clickup.com/t/868jm4wuj

## Test plan
- [x] `ls -la AGENTS.md` resolves to CLAUDE.md
- [x] CLAUDE.md is project docs only — no secrets/credentials/personal content

🤖 Generated with [Claude Code](https://claude.com/claude-code)
